### PR TITLE
Fixed issue #4

### DIFF
--- a/SalesForceBackup/App.config
+++ b/SalesForceBackup/App.config
@@ -21,17 +21,17 @@
     <add key="AzureContainer" value="monthlybackups" />
     <add key="AzureFolder" value="salesforce" />
     <add key="AzureSharedKey" value =""/>
-    <add key="dataExportPage" value="/ui/setup/export/DataExportPage/d?setupid=DataManagementExport&amp;retURL=%2Fui%2Fsetup%2FSetup%3Fsetupid%3DDataManagement" />
-    <add key="downloadPage" value="/servlet/servlet.OrgExport?fileName=" />
-    <add key="filenamePattern" value="&lt;a href=&quot;\/servlet\/servlet.OrgExport\?fileName=(.*?)&quot;.*&gt;download&lt;/a&gt;" />
-    <add key="host" value="na17.salesforce.com" />
-    <add key="organizationId" value="" />
-    <add key="password" value="" />
+    <add key="DataExportPage" value="/ui/setup/export/DataExportPage/d?setupid=DataManagementExport&amp;retURL=%2Fui%2Fsetup%2FSetup%3Fsetupid%3DDataManagement" />
+    <add key="DownloadPage" value="/servlet/servlet.OrgExport?" />
+    <add key="FilenamePattern" value="fileName=(.+?)&quot;" />
+    <add key="Host" value="" />
+    <add key="OrganizationId" value="" />
+    <add key="Password" value="" />
     <add key="S3Bucket" value="monthlybackups" />
     <add key="S3Folder" value="salesforce" />
-    <add key="scheme" value="https" />
-    <add key="uploader" value="Azure" />
-    <add key="username" value="" />
+    <add key="Scheme" value="https" />
+    <add key="Uploader" value="Azure" />
+    <add key="Username" value="" />
     <!--AWSProfileName is used to reference an account that has been registered with the SDK.
 If using AWS Toolkit for Visual Studio then this value is the same value shown in the AWS Explorer.
 It is also possible to register an account using the <solution-dir>/packages/AWSSDK-X.X.X.X/tools/account-management.ps1 PowerShell script
@@ -44,7 +44,7 @@ that is bundled with the nuget package under the tools folder.
   <applicationSettings>
     <SalesForceBackup.Properties.Settings>
       <setting name="SalesForceBackup_SFDC_SforceService" serializeAs="String">
-        <value>https://login.salesforce.com/services/Soap/c/32.0/0DFo000000004N4</value>
+        <value>https://login.salesforce.com/services/Soap/c/32.0</value>
       </setting>
     </SalesForceBackup.Properties.Settings>
   </applicationSettings>

--- a/SalesForceBackup/AppSettingKeys.cs
+++ b/SalesForceBackup/AppSettingKeys.cs
@@ -1,6 +1,4 @@
-﻿using Amazon.Runtime;
-
-namespace SalesForceBackup
+﻿namespace SalesForceBackup
 {
     /// <summary>
     /// Contains the keys that are defined in the App.Config.
@@ -15,17 +13,18 @@ namespace SalesForceBackup
         public const string AzureContainer = "AzureContainer";
         public const string AzureFolder = "AzureFolder";
         public const string AzureSharedKey = "AzureSharedKey";
-        public const string DataExportPage = "dataExportPage";
-        public const string DownloadPage = "downloadPage";
-        public const string FilenamePattern = "filenamePattern";
-        public const string Host = "host";
-        public const string Password = "password";
-        public const string OrganizationId = "organizationId";
+        public const string DataExportPage = "DataExportPage";
+        public const string DownloadPage = "DownloadPage";
+        public const string FilenamePattern = "FilenamePattern";
+        public const string Host = "Host";
+        public const string Password = "Password";
+        public const string OrganizationId = "OrganizationId";
         public const string S3Bucket = "S3Bucket";
         public const string S3Folder = "S3Folder";
-        public const string Scheme = "scheme";
-        public const string Uploader = "uploader";
-        public const string Username = "username";
+        public const string Scheme = "Scheme";
+        public const string SecurityToken = "SecurityToken";
+        public const string Uploader = "Uploader";
+        public const string Username = "Username";
     }
 
     /// <summary>

--- a/SalesForceBackup/IoC/TinyIoC.cs
+++ b/SalesForceBackup/IoC/TinyIoC.cs
@@ -69,7 +69,6 @@ namespace TinyIoC
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Linq;
     using System.Reflection;
 

--- a/SalesForceBackup/Program.cs
+++ b/SalesForceBackup/Program.cs
@@ -30,6 +30,7 @@ namespace SalesForceBackup
             _appSettings = TinyIoCContainer.Current.Resolve<IAppSettings>();
             AssignValuesFromArguments(args);
 
+
             Console.WriteLine("Starting backup...");
             var backup = TinyIoCContainer.Current.Resolve<Backup>();
             backup.Run();
@@ -50,7 +51,6 @@ namespace SalesForceBackup
                 switch (args[i])
                 {
                     case "--help":
-                    case "-h":
                         DisplayHelp();
                         Environment.Exit((int)Enums.ExitCode.Normal);
                         break;
@@ -59,6 +59,12 @@ namespace SalesForceBackup
                         break;
                     case "-p":
                         _appSettings.Set(AppSettingKeys.Password, args[++i]);
+                        break;
+                    case "-t":
+                        _appSettings.Set(AppSettingKeys.SecurityToken, args[++i]);
+                        break;
+                    case "-h":
+                        _appSettings.Set(AppSettingKeys.Host, args[++i]);
                         break;
                     case "-a":
                         _appSettings.Set(AppSettingKeys.AwsAccessKey, args[++i]);

--- a/SalesForceBackup/Properties/AssemblyInfo.cs
+++ b/SalesForceBackup/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 


### PR DESCRIPTION
The login() method of the Salesforce SOAP API failed. This was due to the fact that the security token now has to be appended to the password.

Therefore I added the security token as value of the App.config and changed the parameters of the application. You now can use -t to set the Security Token and -h to set the host. This is a breaking change compared to the original version of this application. Up until now -h was used to display the help.

Additional changes:
* Fixed SSL issue in SalesForceWebDownloader (failed to establish connection)
* Updated regular expressions used to parse the result page (old ones were broken)
* Removed unsused imports
* Unified cases of names of application settings (AppSettingKeys)